### PR TITLE
Make sure OmniAuth is hit with a direct post

### DIFF
--- a/app/views/devise/shared/oauth/_stripe.html.erb
+++ b/app/views/devise/shared/oauth/_stripe.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <%= button_to user_stripe_connect_omniauth_authorize_path, class: 'button-alternative block w-full', form_class: 'block w-full', id: 'sign_in_with_stripe' do %>
+  <%= button_to user_stripe_connect_omniauth_authorize_path, class: 'button-alternative block w-full', form_class: 'block w-full', id: 'sign_in_with_stripe', method: :post, data: {turbo: false} do %>
     <div class="full">
       <i class="text-lg leading-5 mr-3 <%= t('oauth/stripe_accounts.navigation.icon') %>"></i>
       <span class="group-hover:underline"><%= verb %> with Stripe</span>


### PR DESCRIPTION
On a clean install of Bullet Train, running the oauth integration for Xero, the "Log in with Xero" results in a "Not found. Authentication passthru." error message.

Omniauth requires a POST, turbo is using fetch() which results in a failed 404 call.  

Because we'll be redirected anyway, I don't see any reason to use Turbo. Tested locally, will see if there are any specs around this. 

Some background discussion on this common OmniAuth issue: https://github.com/heartcombo/devise/issues/5236 

